### PR TITLE
Improve parser performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 # IDEs
 .idea/
 .vscode/
+
+# Profiling
+*.pprof

--- a/cmd/hcron/main.go
+++ b/cmd/hcron/main.go
@@ -125,7 +125,7 @@ func stream(exprDesc *cron.ExpressionDescriptor, locType cron.LocaleType, reader
 		}
 
 		expr, remaining := normalize(string(line))
-		if expr == "" { // Not a parse-able cron expression
+		if expr == "" { // Not a parse-able CRON expression
 			continue
 		}
 
@@ -155,11 +155,11 @@ func normalize(line string) (expr string, remainder string) {
 	}
 
 	// Line contains invalid chars => Assume it's in crontab format
-	// First 5 parts is the cron expression, the remaining is user and commands
+	// First 5 parts is the CRON expression, the remaining is user and commands
 	if !acceptedCharsRegex.MatchString(line) {
 		return strings.Join(parts[:5], " "), strings.Join(parts[5:], " ")
 	}
 
-	// Only contains accepted cron characters => Assume valid cron expression
+	// Only contains accepted CRON characters => Assume valid CRON expression
 	return line, ""
 }

--- a/cron.go
+++ b/cron.go
@@ -14,20 +14,8 @@ var (
 	lastDayOffsetRegex  = regexp.MustCompile(`l-(\d{1,2})`)
 )
 
-func containsAny(s string, matches []rune) bool {
-	runes := []rune(s)
-	for _, r := range runes {
-		for _, c := range matches {
-			if r == c {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
 type (
+	// ExpressionDescriptor represents the CRON expression descriptor.
 	ExpressionDescriptor struct {
 		isVerbose          bool
 		isDOWStartsAtOne   bool
@@ -38,13 +26,18 @@ type (
 		locales map[LocaleType]Locale
 	}
 
+	// Logger is the logging interface for expression descriptor.
 	Logger interface {
 		Printf(format string, v ...interface{})
 	}
 
+	// Option allows to configure expression descriptor.
 	Option func(exprDesc *ExpressionDescriptor)
 )
 
+// NewDescriptor returns a new CRON expression descriptor based on the list of options.
+// If no options provided, a default CRON expression descriptor will be returned instead.
+// By default, English (Locale_en) will always be loaded.
 func NewDescriptor(options ...Option) (exprDesc *ExpressionDescriptor, err error) {
 	exprDesc = &ExpressionDescriptor{}
 	for _, option := range options {
@@ -73,6 +66,11 @@ func NewDescriptor(options ...Option) (exprDesc *ExpressionDescriptor, err error
 	return exprDesc, nil
 }
 
+// ToDescription converts the CRON expression to the human readable string in specified locale.
+// If the specified locale had not been loaded by the CRON expression descriptor, the result will be
+// returned in English (Locale_en) by default.
+//
+// To configure supported locales of the CRON expression descriptor, please see the SetLocales() option.
 func (e *ExpressionDescriptor) ToDescription(expr string, loc LocaleType) (desc string, err error) {
 	var exprParts []string
 	if exprParts, err = e.parser.Parse(expr); err != nil {
@@ -406,6 +404,19 @@ func (e *ExpressionDescriptor) getLocale(loc LocaleType) Locale {
 		return e.locales[Locale_en] // Fall back to default
 	}
 	return v
+}
+
+func containsAny(s string, matches []rune) bool {
+	runes := []rune(s)
+	for _, r := range runes {
+		for _, c := range matches {
+			if r == c {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func formatTime(hour, minute, second string, locale Locale, isUse24HourTimeFormat bool) string {

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -9,8 +9,6 @@ import (
 
 const expr = "0 * 9 LW JAN-OCT 1-5 2000/10"
 
-// const expr = "00 11,16 * * *"
-
 func main() {
 	exprDesc, err := cron.NewDescriptor(
 		cron.Use24HourTimeFormat(true),

--- a/locale.go
+++ b/locale.go
@@ -74,6 +74,8 @@ type (
 	LocaleType string
 	LocaleKey  string
 
+	// Locale is the interface to a specific i18n.
+	// The methods of Locale interface returns the corresponding i18n of a specific key.
 	Locale interface {
 		GetLocaleType() (typ LocaleType)
 		GetBool(key LocaleKey) (value bool)
@@ -81,6 +83,7 @@ type (
 		GetSlice(key LocaleKey) (values []string)
 	}
 
+	// LocaleLoader holds the map of i18n strings in a specific language (localType).
 	LocaleLoader struct {
 		localeType LocaleType
 		data       map[string]interface{}

--- a/option.go
+++ b/option.go
@@ -1,29 +1,40 @@
 package cron
 
+// SetLogger allows the expression descriptor to output log via logger.
 func SetLogger(logger Logger) Option {
 	return func(exprDesc *ExpressionDescriptor) {
 		exprDesc.logger = logger
 	}
 }
 
+// Verbose sets the expression descriptor to output string in verbose format or not.
+//
+// Example: cronExpression = "* * 5 * * * *"
+//  - verbose = false: Every second, between 05:00 and 05:59
+//  - verbose = true: Every second, every minute, between 05:00 and 05:59, every day
 func Verbose(v bool) Option {
 	return func(exprDesc *ExpressionDescriptor) {
 		exprDesc.isVerbose = v
 	}
 }
 
+// DayOfWeekStartsAtOne configures first day of the week is Monday (index 1) or Sunday (index 0, default).
 func DayOfWeekStartsAtOne(v bool) Option {
 	return func(exprDesc *ExpressionDescriptor) {
 		exprDesc.isDOWStartsAtOne = v
 	}
 }
 
+// Use24HourTimeFormat configures the expression descriptor to output time in 24-hour format (14:00) or
+// 12-hour format (2PM, default).
 func Use24HourTimeFormat(v bool) Option {
 	return func(exprDesc *ExpressionDescriptor) {
 		exprDesc.is24HourTimeFormat = v
 	}
 }
 
+// SetLocales initializes the list of initial locales that the expression descriptor will output in.
+// By default, the expression descriptor always initialize English (Locale_en).
 func SetLocales(locales ...LocaleType) Option {
 	return func(exprDesc *ExpressionDescriptor) {
 		loaders, err := NewLocaleLoaders(locales...)

--- a/parser.go
+++ b/parser.go
@@ -68,11 +68,15 @@ type (
 		isDOWStartsAtOne bool
 	}
 
+	// Parser represents the cron parser.
 	Parser interface {
 		Parse(expr string) (exprParts []string, err error)
 	}
 )
 
+// Parse parses, normalizes and validates the CRON expression.
+// If the CRON expression is valid, then the returned list always the normalized 7-part-CRON format.
+// Example: "* 5 * * *" => ["", "*", "5", "*", "*", "*", ""]
 func (p *cronParser) Parse(expr string) (exprParts []string, err error) {
 	exprParts, err = p.extractExprParts(expr)
 	if err != nil {
@@ -102,7 +106,7 @@ func (p *cronParser) extractExprParts(expr string) (exprParts []string, err erro
 	case len(parts) < 5:
 		return nil, fmt.Errorf("expression has only %d part(s), at least 5 parts required: %w", len(parts), InvalidExprError)
 	case len(parts) == 5:
-		// Expression has 5 parts (standard POSIX cron)
+		// Expression has 5 parts (standard POSIX CRON)
 		// => Prepend 1 and append 1 empty part at the beginning and the end of exprParts
 		copy(exprParts[1:], append(parts, ""))
 	case len(parts) == 6:

--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,7 @@
 package cron
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"regexp"
@@ -267,21 +268,24 @@ func (p *cronParser) normalize(exprParts []string) (err error) {
 	return nil
 }
 
-// TODO: Regex is really expensive here. Improve it
 func (p *cronParser) validate(exprParts []string) (err error) {
 	// Second
+	buf := bytes.NewBuffer(make([]byte, 0, 8))
 	getNumbersFunc := func(s string) (numbers []string) {
-		runes := []rune(s)
-		var num []rune
-		for _, r := range runes {
-			if r >= '0' && r <= '9' {
-				num = append(num, r)
+		for _, b := range s {
+			if b >= '0' && b <= '9' {
+				_, _ = buf.WriteRune(b)
 			} else {
-				if len(num) > 0 {
-					numbers = append(numbers, string(num))
-					num = make([]rune, 0)
+				if buf.Len() > 0 {
+					numbers = append(numbers, buf.String())
+					buf.Reset()
 				}
 			}
+		}
+
+		if buf.Len() > 0 {
+			numbers = append(numbers, buf.String())
+			buf.Reset()
 		}
 		return numbers
 	}

--- a/parser.go
+++ b/parser.go
@@ -29,8 +29,6 @@ var (
 	rangeRegex = regexp.MustCompile(`^[*\-,]`)
 
 	invalidCharsDOWDOMRegex = regexp.MustCompile(`[a-km-vx-zA-KM-VX-Z]`)
-
-	numberRegex = regexp.MustCompile(`(\d+)`)
 )
 
 var (
@@ -269,7 +267,7 @@ func (p *cronParser) normalize(exprParts []string) (err error) {
 }
 
 func (p *cronParser) validate(exprParts []string) (err error) {
-	// Second
+	// Extract the numbers from s string
 	buf := bytes.NewBuffer(make([]byte, 0, 8))
 	getNumbersFunc := func(s string) (numbers []string) {
 		for _, b := range s {
@@ -337,11 +335,11 @@ func (p *cronParser) validate(exprParts []string) (err error) {
 	return nil
 }
 
+// isValidNumbers checks if all the numbers in the list is in range (lowerBound, upperBound).
 func isValidNumbers(matches []string, lowerBound, upperBound int) bool {
 	for _, m := range matches {
 		num, err := strconv.Atoi(m)
 		if err != nil {
-			// TODO: verbose
 			return false
 		}
 		if num < lowerBound || num > upperBound {


### PR DESCRIPTION
```
$ benchstat before_result.pprof after_result.pprof 
name                                old time/op    new time/op    delta
ExpressionDescriptor_ToDescription    15.6µs ± 3%    11.8µs ± 1%  -24.52%  (p=0.000 n=10+9)

name                                old alloc/op   new alloc/op   delta
ExpressionDescriptor_ToDescription    5.63kB ± 0%    4.59kB ± 0%  -18.47%  (p=0.000 n=10+10)

name                                old allocs/op  new allocs/op  delta
ExpressionDescriptor_ToDescription      92.0 ± 0%      90.0 ± 0%   -2.17%  (p=0.000 n=10+10)

```